### PR TITLE
feat: add segmented video writer and streaming run

### DIFF
--- a/core/atomic_components/writer.py
+++ b/core/atomic_components/writer.py
@@ -1,21 +1,38 @@
+"""Video writing utilities."""
+
 import imageio
 import os
+from typing import Optional
 
 
 class VideoWriterByImageIO:
-    def __init__(self, video_path, fps=25, **kwargs):
-        video_format = kwargs.get("format", "mp4")  # default is mp4 format
-        codec = kwargs.get("vcodec", "libx264")  # default is libx264 encoding
-        quality = kwargs.get("quality")  # video quality
-        pixelformat = kwargs.get("pixelformat", "yuv420p")  # video pixel format
-        macro_block_size = kwargs.get("macro_block_size", 2)
-        ffmpeg_params = ["-crf", str(kwargs.get("crf", 18))]
+    """Wrapper around :mod:`imageio` video writer used by the pipeline.
 
-        os.makedirs(os.path.dirname(video_path), exist_ok=True)
-        
-        writer = imageio.get_writer(
-            video_path,
-            fps=fps,
+    The original implementation exposed a callable interface.  To support
+    segmented writing we provide an explicit ``start_segment``/``write_frame``
+    API while keeping the default behaviour of producing a single file.
+    """
+
+    def __init__(self, video_path: str, fps: int = 25, **kwargs) -> None:
+        self.video_path = video_path
+        self.fps = fps
+        self.kwargs = kwargs
+        self.writer: Optional[imageio.core.format.Writer] = None
+
+    # ------------------------------------------------------------------
+    def _open_writer(self) -> None:
+        """Internal helper to instantiate the ``imageio`` writer."""
+        video_format = self.kwargs.get("format", "mp4")
+        codec = self.kwargs.get("vcodec", "libx264")
+        quality = self.kwargs.get("quality")
+        pixelformat = self.kwargs.get("pixelformat", "yuv420p")
+        macro_block_size = self.kwargs.get("macro_block_size", 2)
+        ffmpeg_params = ["-crf", str(self.kwargs.get("crf", 18))]
+
+        os.makedirs(os.path.dirname(self.video_path), exist_ok=True)
+        self.writer = imageio.get_writer(
+            self.video_path,
+            fps=self.fps,
             format=video_format,
             codec=codec,
             quality=quality,
@@ -23,14 +40,102 @@ class VideoWriterByImageIO:
             pixelformat=pixelformat,
             macro_block_size=macro_block_size,
         )
-        self.writer = writer
 
-    def __call__(self, img, fmt="bgr"):
-        if fmt == "bgr":
-            frame = img[..., ::-1]
-        else:
-            frame = img
+    # ------------------------------------------------------------------
+    def start_segment(self) -> None:
+        """Start writing a new segment to ``self.video_path``."""
+        if self.writer is not None:
+            raise RuntimeError("segment already started")
+        self._open_writer()
+
+    def write_frame(self, img, fmt: str = "bgr") -> None:
+        """Append a frame to the current segment."""
+        if self.writer is None:
+            raise RuntimeError("call start_segment() before write_frame()")
+        frame = img[..., ::-1] if fmt == "bgr" else img
         self.writer.append_data(frame)
 
-    def close(self):
+    def close_segment(self):
+        """Finalize the current segment."""
+        if self.writer is None:
+            return None
         self.writer.close()
+        self.writer = None
+        return self.video_path
+
+    # Backwards compatibility -------------------------------------------------
+    def __call__(self, img, fmt: str = "bgr"):
+        self.write_frame(img, fmt=fmt)
+
+    def close(self):
+        return self.close_segment()
+
+
+class SegmentedVideoWriter:
+    """Create sequential ``segment_XXXXX.mp4`` files or in-memory buffers."""
+
+    def __init__(self, base_path: str, fps: int = 25, in_memory: bool = False, **kwargs) -> None:
+        self.base_path = base_path
+        self.fps = fps
+        self.kwargs = kwargs
+        self.in_memory = in_memory
+        self.counter = 0
+        self.writer: Optional[imageio.core.format.Writer] = None
+        self.current_output = None  # path or bytes
+
+    def _next_path(self) -> str:
+        os.makedirs(self.base_path, exist_ok=True)
+        name = f"segment_{self.counter:05d}.mp4"
+        self.counter += 1
+        return os.path.join(self.base_path, name)
+
+    def start_segment(self) -> None:
+        if self.writer is not None:
+            raise RuntimeError("segment already started")
+        if self.in_memory:
+            self.writer = imageio.get_writer(
+                imageio.RETURN_BYTES,
+                fps=self.fps,
+                format=self.kwargs.get("format", "mp4"),
+                codec=self.kwargs.get("vcodec", "libx264"),
+                pixelformat=self.kwargs.get("pixelformat", "yuv420p"),
+                macro_block_size=self.kwargs.get("macro_block_size", 2),
+                ffmpeg_params=["-crf", str(self.kwargs.get("crf", 18))],
+            )
+            self.current_output = None
+        else:
+            path = self._next_path()
+            self.writer = imageio.get_writer(
+                path,
+                fps=self.fps,
+                format=self.kwargs.get("format", "mp4"),
+                codec=self.kwargs.get("vcodec", "libx264"),
+                pixelformat=self.kwargs.get("pixelformat", "yuv420p"),
+                macro_block_size=self.kwargs.get("macro_block_size", 2),
+                ffmpeg_params=["-crf", str(self.kwargs.get("crf", 18))],
+            )
+            self.current_output = path
+
+    def write_frame(self, img, fmt: str = "bgr") -> None:
+        if self.writer is None:
+            raise RuntimeError("call start_segment() before write_frame()")
+        frame = img[..., ::-1] if fmt == "bgr" else img
+        self.writer.append_data(frame)
+
+    def close_segment(self):
+        if self.writer is None:
+            return None
+        if self.in_memory:
+            data = self.writer.close()
+            self.writer = None
+            return data
+        else:
+            self.writer.close()
+            path = self.current_output
+            self.writer = None
+            self.current_output = None
+            return path
+
+    def close(self):
+        return self.close_segment()
+

--- a/inference.py
+++ b/inference.py
@@ -7,6 +7,7 @@ import torch
 import pickle
 
 from stream_pipeline_offline import StreamSDK
+from core.atomic_components.writer import SegmentedVideoWriter
 
 
 def seed_everything(seed):
@@ -61,6 +62,52 @@ def run(SDK: StreamSDK, audio_path: str, source_path: str, output_path: str, mor
     os.system(cmd)
 
     print(output_path)
+
+
+def stream_run(
+    SDK: StreamSDK,
+    audio_path: str,
+    source_path: str,
+    output_dir: str,
+    more_kwargs: str | dict = {},
+):
+    """Stream audio and yield individual MP4 segments.
+
+    Parameters are similar to :func:`run` but ``output_dir`` points to a
+    directory where ``segment_XXXXX.mp4`` files will be written.
+    """
+
+    if isinstance(more_kwargs, str):
+        more_kwargs = load_pkl(more_kwargs)
+    setup_kwargs = more_kwargs.get("setup_kwargs", {})
+    run_kwargs = more_kwargs.get("run_kwargs", {})
+    setup_kwargs["online_mode"] = True
+
+    SDK.setup(source_path, output_dir, writer_cls=SegmentedVideoWriter, **setup_kwargs)
+
+    chunksize = run_kwargs.get("chunksize", (3, 5, 2))
+
+    audio, sr = librosa.core.load(audio_path, sr=16000)
+    audio = np.concatenate([np.zeros((chunksize[0] * 640,), dtype=np.float32), audio], 0)
+    split_len = int(sum(chunksize) * 0.04 * 16000) + 80
+
+    first = True
+    for i in range(0, len(audio), chunksize[1] * 640):
+        audio_chunk = audio[i:i + split_len]
+        if len(audio_chunk) < split_len:
+            audio_chunk = np.pad(audio_chunk, (0, split_len - len(audio_chunk)), mode="constant")
+
+        if not first:
+            SDK.writer.start_segment()
+        first = False
+
+        SDK.run_chunk(audio_chunk, chunksize)
+        SDK.flush()
+        seg = SDK.writer.close_segment()
+        if seg is not None:
+            yield seg
+
+    SDK.close()
 
 
 if __name__ == "__main__":

--- a/stream_pipeline_offline.py
+++ b/stream_pipeline_offline.py
@@ -1,5 +1,6 @@
 import threading
 import queue
+import time
 import numpy as np
 import traceback
 from tqdm import tqdm
@@ -71,7 +72,7 @@ class StreamSDK:
                 ctrl_info[i] = item
         self.ctrl_info = ctrl_info
 
-    def setup(self, source_path, output_path, **kwargs):
+    def setup(self, source_path, output_path, writer_cls=VideoWriterByImageIO, **kwargs):
 
         # ======== Prepare Options ========
         kwargs = self._merge_kwargs(self.default_kwargs, kwargs)
@@ -196,8 +197,14 @@ class StreamSDK:
 
         # ======== Video Writer ========
         self.output_path = output_path
-        self.tmp_output_path = output_path + ".tmp.mp4"
-        self.writer = VideoWriterByImageIO(self.tmp_output_path)
+        if writer_cls is VideoWriterByImageIO:
+            self.tmp_output_path = output_path + ".tmp.mp4"
+            writer_path = self.tmp_output_path
+        else:
+            self.tmp_output_path = None
+            writer_path = output_path
+        self.writer = writer_cls(writer_path)
+        self.writer.start_segment()
         self.writer_pbar = tqdm(desc="writer")
 
         # ======== Audio Feat Buffer ========
@@ -264,7 +271,7 @@ class StreamSDK:
             if item is None:
                 break
             res_frame_rgb = item
-            self.writer(res_frame_rgb, fmt="rgb")
+            self.writer.write_frame(res_frame_rgb, fmt="rgb")
             self.writer_pbar.update()
 
     def putback_worker(self):
@@ -520,7 +527,7 @@ class StreamSDK:
             thread.join()
 
         try:
-            self.writer.close()
+            self.writer.close_segment()
             self.writer_pbar.close()
         except:
             traceback.print_exc()
@@ -538,6 +545,19 @@ class StreamSDK:
                 break
             except queue.Full:
                 continue
+
+    def flush(self):
+        """Block until all internal queues are empty."""
+        queues = [
+            self.audio2motion_queue,
+            self.motion_stitch_queue,
+            self.warp_f3d_queue,
+            self.decode_f3d_queue,
+            self.putback_queue,
+            self.writer_queue,
+        ]
+        while any(not q.empty() for q in queues):
+            time.sleep(0.1)
 
     
 


### PR DESCRIPTION
## Summary
- add `SegmentedVideoWriter` to emit sequential MP4 segments or in-memory buffers
- allow `StreamSDK.setup` to accept a custom writer class and provide a `flush` helper
- introduce `stream_run` generator to yield video chunks in online mode

## Testing
- `python -m py_compile core/atomic_components/writer.py stream_pipeline_offline.py inference.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891c8d702c0832c81a5c6a208182036