### PR TITLE
feat: allow custom writer kwargs for streaming

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -5,6 +5,7 @@ import numpy as np
 import random
 import torch
 import pickle
+from typing import Generator
 
 from stream_pipeline_offline import StreamSDK
 from core.atomic_components.writer import SegmentedVideoWriter
@@ -70,11 +71,15 @@ def stream_run(
     source_path: str,
     output_dir: str,
     more_kwargs: str | dict = {},
-):
-    """Stream audio and yield individual MP4 segments.
+) -> Generator[bytes, None, None]:
+    """Stream audio and yield individual MP4 segments as bytes.
 
-    Parameters are similar to :func:`run` but ``output_dir`` points to a
-    directory where ``segment_XXXXX.mp4`` files will be written.
+    Parameters are similar to :func:`run` but ``output_dir`` is kept for
+    API compatibility. Each yielded value contains the encoded MP4 data
+    for a segment.
+
+    Yields:
+        bytes: Encoded MP4 data for each segment.
     """
 
     if isinstance(more_kwargs, str):
@@ -83,7 +88,13 @@ def stream_run(
     run_kwargs = more_kwargs.get("run_kwargs", {})
     setup_kwargs["online_mode"] = True
 
-    SDK.setup(source_path, output_dir, writer_cls=SegmentedVideoWriter, **setup_kwargs)
+    SDK.setup(
+        source_path,
+        output_dir,
+        writer_cls=SegmentedVideoWriter,
+        writer_kwargs={"in_memory": True},
+        **setup_kwargs,
+    )
 
     chunksize = run_kwargs.get("chunksize", (3, 5, 2))
 

--- a/stream_pipeline_offline.py
+++ b/stream_pipeline_offline.py
@@ -72,7 +72,16 @@ class StreamSDK:
                 ctrl_info[i] = item
         self.ctrl_info = ctrl_info
 
-    def setup(self, source_path, output_path, writer_cls=VideoWriterByImageIO, **kwargs):
+    def setup(
+        self,
+        source_path,
+        output_path,
+        writer_cls=VideoWriterByImageIO,
+        writer_kwargs=None,
+        **kwargs,
+    ):
+
+        writer_kwargs = writer_kwargs or {}
 
         # ======== Prepare Options ========
         kwargs = self._merge_kwargs(self.default_kwargs, kwargs)
@@ -203,7 +212,7 @@ class StreamSDK:
         else:
             self.tmp_output_path = None
             writer_path = output_path
-        self.writer = writer_cls(writer_path)
+        self.writer = writer_cls(writer_path, **writer_kwargs)
         self.writer.start_segment()
         self.writer_pbar = tqdm(desc="writer")
 


### PR DESCRIPTION
## Summary
- allow passing writer kwargs to StreamSDK.setup
- stream_run yields in-memory MP4 bytes and sets up writer for in-memory segments

## Testing
- `python -m py_compile stream_pipeline_offline.py inference.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892df4be2cc832c8b186a88b8eeaf2d